### PR TITLE
Pure annotations are made optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 *.log
+
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -131,3 +131,64 @@ const Img = function () {
 Img.displayName = "DS.Img";
 ```
 
+### `skipPureAnnotations`
+
+Allows you to skip `#__PURE__` annotations for displayName property assignment for tree-shaking support. `false` by default.
+
+#### Example 1: 
+
+```
+{
+    "plugins": ["@probablyup/babel-plugin-react-displayname", {
+       "skipPureAnnotations": false
+    }]
+}
+```
+
+from: 
+
+```jsx
+const Img = function () {
+  return <img />;
+};
+```
+
+to:
+
+```jsx
+const Img = function () {
+  return <img />;
+};
+/*#__PURE__*/Object.assign(Img, {
+    "displayName": "Img"
+});
+```
+
+#### Example 2:
+
+```
+{
+    "plugins": ["@probablyup/babel-plugin-react-displayname", {
+       "skipPureAnnotations": true
+    }]
+}
+```
+
+from:
+
+```jsx
+const Img = function () {
+  return <img />;
+};
+```
+
+to:
+
+```jsx
+const Img = function () {
+  return <img />;
+};
+/*#__PURE__*/Object.assign(Img, {
+    "displayName": "Img"
+});
+```

--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,7 @@ function addDisplayNamesToFunctionComponent(types, path, options) {
     setInternalFunctionName(types, path, name);
   }
 
-  const displayNameStatement = createDisplayNameStatement(types, componentIdentifiers, name);
+  const displayNameStatement = createDisplayNameStatement(types, componentIdentifiers, name, !options.skipPureAnnotations);
 
   assignmentPath.insertAfter(displayNameStatement);
 
@@ -355,8 +355,9 @@ function hasBeenAssignedNext(types, assignmentPath, pattern) {
  * @param {Types} types content of @babel/types package
  * @param {componentIdentifier[]} componentIdentifiers list of { id, computed } objects
  * @param {string} displayName name of the function component
+ * @param {boolean} pureAnnotationsEnabled flag for prepanding the #__PURE__ comments to the displayName statement
  */
-function createDisplayNameStatement(types, componentIdentifiers, displayName, helperIdentifier) {
+function createDisplayNameStatement(types, componentIdentifiers, displayName, pureAnnotationsEnabled) {
   const node = createMemberExpression(types, componentIdentifiers);
 
   const expression = types.callExpression(
@@ -369,7 +370,9 @@ function createDisplayNameStatement(types, componentIdentifiers, displayName, he
     ]
   );
 
-  annotateAsPure(expression);
+  if (pureAnnotationsEnabled) {
+    annotateAsPure(expression);
+  }
 
   return types.expressionStatement(expression);
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -23,6 +23,11 @@ const transformWithTemplate = (code) =>
     template: 'Foo.%s',
   });
 
+const transformWithoutPureAnnotations = (code) =>
+    transform(code, {
+      skipPureAnnotations: true,
+    });
+
 describe('babelDisplayNamePlugin', () => {
   it('should add display name to function expression components', () => {
     expect(
@@ -1148,6 +1153,22 @@ describe('babelDisplayNamePlugin', () => {
       };
       /*#__PURE__*/Object.assign(Test, {
         "displayName": "Foo.Test"
+      });"
+    `);
+  });
+
+  it('should not add pure annotations if the skipPureAnnotations is true', () => {
+    expect(
+        transformWithoutPureAnnotations(`
+      const Test = function() {
+        return <img/>;
+      }`)
+    ).toMatchInlineSnapshot(`
+      "const Test = function () {
+        return React.createElement("img", null);
+      };
+      Object.assign(Test, {
+        "displayName": "Test"
       });"
     `);
   });


### PR DESCRIPTION
Added a new optional flag called `skipPureAnnotations` (false by default) to skip generating `#__PURE__` annotations.

Reasoning:

Currently Webpack relies on Terser to tree-shake, instead of supporting native Tree-shaking via ESM modules like Rollup does.

When the pure annotations are added to `Object.assign` calls, Terser by default removes them (`side_effects: true` out of the box) and you can't have the human readable displayName values in your prod build as a result.

